### PR TITLE
Fixes compilation when using the library through SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 
@@ -51,7 +51,11 @@ let package = Package(
                 "secp256k1/modules/ecdh",
                 "secp256k1/modules/recovery"
             ],
-            publicHeadersPath: "secp256k1/include"),
+            publicHeadersPath: "secp256k1/include",
+            cSettings: [
+                .headerSearchPath("secp256k1/src")
+            ]
+        ),
         .target(
             name: "secp256k1",
             dependencies: ["libsecp256k1"],


### PR DESCRIPTION
Currently there is an issue when the library is imported with SwiftPM.

![Screenshot 2022-02-09 at 00 22 05](https://user-images.githubusercontent.com/4331056/153093403-d4965622-846a-4c58-851a-87c25c7b34fc.png)

It seems that in the `Package.swift`, the headers inside the `src` folder are not being included in the search paths, causing the compilation error.

The issue does not happen with Cocoapods because the podspec is including all header files under the `src` folder.

```
s.private_header_files = 'secp256k1/Classes/secp256k1_ec_mult_static_context.h', 'secp256k1/Classes/secp256k1/*.h', 'secp256k1/Classes/secp256k1/{contrib,src}/*.h', 'secp256k1/Classes/secp256k1/src/modules/{recovery, ecdh}/*.h'
```

The fix with SwiftPM is then to update the `swift-tools-version` so the `cSettings` property can be used.
Then add `secp256k1/src` as a header search path.