### PR TITLE
Remove invalid paths from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,18 +38,13 @@ let package = Package(
                 "secp256k1/src/bench_sign.c",
                 "secp256k1/src/bench_verify.c",
                 "secp256k1/src/bench.h",
-                "secp256k1/src/modules/ecdh/tests_impl.h",
-                "secp256k1/src/modules/recovery/tests_impl.h",
-
                 "exporter"
             ],
             sources: [
                 ".",
                 "secp256k1/src",
                 "secp256k1/include",
-                "secp256k1/contrib",
-                "secp256k1/modules/ecdh",
-                "secp256k1/modules/recovery"
+                "secp256k1/contrib"
             ],
             publicHeadersPath: "secp256k1/include",
             cSettings: [


### PR DESCRIPTION
Fixes: https://github.com/Boilertalk/secp256k1.swift/issues/13